### PR TITLE
Fix Encoding::UndefinedConversionError

### DIFF
--- a/lib/doc_raptor.rb
+++ b/lib/doc_raptor.rb
@@ -33,7 +33,8 @@ class DocRaptor
       :document_type              => "pdf",
       :test                       => false,
       :async                      => false,
-      :raise_exception_on_failure => false
+      :raise_exception_on_failure => false,
+      :encoding                   => "ascii-8bit"
     }
     options = default_options.merge(options)
     raise_exception_on_failure = options[:raise_exception_on_failure]
@@ -61,7 +62,7 @@ class DocRaptor
 
     if block_given?
       ret_val = nil
-      Tempfile.open("docraptor") do |f|
+      Tempfile.open("docraptor", :encoding => options[:encoding]) do |f|
         f.sync = true
         f.write(response.body)
         f.rewind


### PR DESCRIPTION
I ran into this issue when using the gem in our Rails 4 app. I found the solution in issue #6 but it has not been fixed yet. I wasn't exactly sure how to test this, so unless anyone provides any additional assistance, this is the best I can do.