### PR TITLE
Force ascii-8bit encoding when creating tempfile

### DIFF
--- a/lib/doc_raptor.rb
+++ b/lib/doc_raptor.rb
@@ -61,7 +61,7 @@ class DocRaptor
 
     if block_given?
       ret_val = nil
-      Tempfile.open("docraptor") do |f|
+      Tempfile.open("docraptor", :encoding => "ascii-8bit") do |f|
         f.sync = true
         f.write(response.body)
         f.rewind


### PR DESCRIPTION
As I understand it, the default in application.rb for Rails 3+ is:

  config.encoding = "utf-8"

The content that comes back from docraptor is encoded ascii-8bit. If the
default Rails encoding is not changed, then the your application will
try to convert the content, and the gem frequently throws an error
similar to:

  "\xE2" from ASCII-9BIT to UTF-8

This error is originating with the creation of a tempfile.

This fix adds an option to the Tempfile.open call to force encoding to
ascii-8bit.